### PR TITLE
Update render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -25,23 +25,5 @@ services:
         name: mysql
         envVarKey: MYSQL_PASSWORD
 
-- type: pserv
-  name: mysql
-  plan: standard
-  env: docker
-  repo: https://github.com/render-examples/mysql
-  autoDeploy: false
-  disk:
-    name: mysql
-    mountPath: /var/lib/mysql
-    sizeGB: 1
-  envVars:
-    - key: MYSQL_DATABASE
-      value: ghostdb
-    - key: MYSQL_USER
-      value: mysql
-    - key: MYSQL_PASSWORD
-      generateValue: true
-    - key: MYSQL_ROOT_PASSWORD
-      generateValue: true
+
 


### PR DESCRIPTION
- type: pserv
  name: mysql
  plan: standard
  env: docker
  repo: https://github.com/render-examples/mysql
  autoDeploy: false
  disk:
    name: mysql
    mountPath: /var/lib/mysql
    sizeGB: 1
  envVars:
    - key: MYSQL_DATABASE
      value: ghostdb
    - key: MYSQL_USER
      value: mysql
    - key: MYSQL_PASSWORD
      generateValue: true
    - key: MYSQL_ROOT_PASSWORD
      generateValue: true